### PR TITLE
Support Tornado 6, remove setuptools_scm

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,11 @@
 Version History
 ===============
 
+`3.0.1`_ (5 Mar 2019)
+---------------------
+- Set Tornado PIN to >=5, <7
+- Remove setuptools_scm
+
 `3.0.0`_ (4 Dec 2018)
 ---------------------
 - Add MessagePack dependencies to package extras (eg. `pip install sprockets.mixins.mediatype[msgpack]`)

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -71,7 +71,8 @@ Version History
 ---------------------
 - Initial Release
 
-.. _Next Release: https://github.com/sprockets/sprockets.mixins.mediatype/compare/3.0.0...HEAD
+.. _Next Release: https://github.com/sprockets/sprockets.mixins.mediatype/compare/3.0.1...HEAD
+.. _3.0.1: https://github.com/sprockets/sprockets.mixins.mediatype/compare/3.0.0...3.0.1
 .. _3.0.0: https://github.com/sprockets/sprockets.mixins.mediatype/compare/2.2.2...3.0.0
 .. _2.2.2: https://github.com/sprockets/sprockets.mixins.mediatype/compare/2.2.1...2.2.2
 .. _2.2.1: https://github.com/sprockets/sprockets.mixins.mediatype/compare/2.2.0...2.2.1

--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,2 +1,2 @@
 ietfparse>=1.5.1,<2
-tornado>=5,<6
+tornado>=5,<7

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,4 +14,7 @@ exclude = build,env,.eggs
 [nosetests]
 cover-branches = 1
 cover-erase = 1
-cover-package = sprockets.mixins
+cover-package = sprockets.mixins.mediatype
+logging-level=DEBUG
+verbosity=2
+with-coverage=1

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
-#
 import pathlib
 import setuptools
 
+from sprockets.mixins import mediatype
 
 REPO_DIR = pathlib.Path(__name__).parent
 
@@ -23,6 +23,7 @@ def read_requirements(name):
 
 setuptools.setup(
     name='sprockets.mixins.mediatype',
+    version=mediatype.__version__,
     description='A mixin for reporting handling content-type/accept headers',
     long_description=REPO_DIR.joinpath('README.rst').read_text(),
     url='https://github.com/sprockets/sprockets.mixins.mediatype',
@@ -41,18 +42,12 @@ setuptools.setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
-    packages=[
-        'sprockets',
-        'sprockets.mixins',
-        'sprockets.mixins.mediatype'
-    ],
+    packages=setuptools.find_packages(),
     install_requires=read_requirements('requires/installation.txt'),
     tests_require=read_requirements('requires/testing.txt'),
     extras_require={
         'msgpack': ['u-msgpack-python>=2.5.0,<3']
     },
-    setup_requires=['setuptools_scm'],
-    use_scm_version=True,
     namespace_packages=['sprockets', 'sprockets.mixins'],
     test_suite='nose.collector',
     python_requires='>=3.7',

--- a/sprockets/__init__.py
+++ b/sprockets/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/sprockets/mixins/__init__.py
+++ b/sprockets/mixins/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/sprockets/mixins/mediatype/__init__.py
+++ b/sprockets/mixins/mediatype/__init__.py
@@ -6,13 +6,13 @@ try:
     from .content import (ContentMixin, ContentSettings,
                           add_binary_content_type, add_text_content_type,
                           set_default_content_type)
-except ImportError as error:  # pragma no cover
+except ImportError as error:  # noqa: F841  # pragma no cover
     def _error_closure(*args, **kwargs):
-        raise error
+        raise error  # noqa: F821
 
     class ErrorClosureClass(object):
         def __init__(self, *args, **kwargs):
-            raise error
+            raise error  # noqa: F821
 
     ContentMixin = ErrorClosureClass
     ContentSettings = ErrorClosureClass

--- a/sprockets/mixins/mediatype/__init__.py
+++ b/sprockets/mixins/mediatype/__init__.py
@@ -2,11 +2,27 @@
 sprockets.mixins.mediatype
 
 """
+try:
+    from .content import (ContentMixin, ContentSettings,
+                          add_binary_content_type, add_text_content_type,
+                          set_default_content_type)
+except ImportError as error:  # pragma no cover
+    def _error_closure(*args, **kwargs):
+        raise error
 
-from .content import (ContentMixin, ContentSettings,
-                      add_binary_content_type, add_text_content_type,
-                      set_default_content_type)
+    class ErrorClosureClass(object):
+        def __init__(self, *args, **kwargs):
+            raise error
 
+    ContentMixin = ErrorClosureClass
+    ContentSettings = ErrorClosureClass
+    add_binary_content_type = _error_closure
+    add_text_content_type = _error_closure
+    set_default_content_type = _error_closure
+
+
+version_info = (3, 0, 1)
+__version__ = '.'.join(str(x) for x in version_info)
 
 __all__ = ['ContentMixin', 'ContentSettings', 'add_binary_content_type',
            'add_text_content_type', 'set_default_content_type',


### PR DESCRIPTION
- Tornado 6 was released and everything still works, so make widen the pin to >=5,<7
- setuptools_scm is too opinionated and magical for my taste, remove it