### PR TITLE
Change log level on decode failure log

### DIFF
--- a/sprockets/mixins/mediatype/content.py
+++ b/sprockets/mixins/mediatype/content.py
@@ -336,7 +336,7 @@ class ContentMixin:
             try:
                 self._request_body = handler.from_bytes(self.request.body)
             except Exception:
-                self._logger.exception('failed to decode request body')
+                self._logger.error('failed to decode request body')
                 raise web.HTTPError(400, 'failed to decode request')
 
         return self._request_body


### PR DESCRIPTION
Don't print tracebacks when failing to decode the body.