### PR TITLE
Make contribution guidelines more visible

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -14,7 +14,7 @@ environment for your endeavors::
    $ python3 -m venv env
 
 Don't worry about writing code against previous versions of Python unless
-you you don't have a choice.  That is why we run our tests through `tox`_.
+you you don't have a choice.  That is why we run our tests using tox.
 The next step is to install the development tools that this project uses.
 These are listed in *requires/development.txt*::
 
@@ -43,10 +43,10 @@ For other commands, *setup.py* is the swiss-army knife in your development
 tool chest.  It provides the following commands:
 
 **./setup.py build_sphinx**
-   Generate the documentation using `sphinx`_.
+   Generate the documentation using sphinx.
 
 **./setup.py flake8**
-   Run `flake8`_ over the code and report style violations.
+   Run flake8 over the code and report style violations.
 
 If any of the preceding commands give you problems, then you will have to
 fix them **before** your pull request will be accepted.
@@ -59,8 +59,8 @@ unittest runner::
    $ python -m unittest tests
 
 That's the quick way to run tests.  The slightly longer way is to run
-the `tox`_ utility.  It will run the test suite against all of the supported
-python versions in parallel.  This is essentially what Travis-CI
+the tox utility.  It will run the test suite against all of the supported
+python versions in parallel.  This is essentially what our CI pipeline
 will do when you issue a pull request anyway::
 
    $ tox -p auto
@@ -84,9 +84,5 @@ posterity.  You've probably already cloned this repository and created a
 new branch.  If you haven't, then checkout what you have as a branch and
 roll back *master* to where you found it.  Then push your repository up
 to github and issue a pull request.  Describe your changes in the request,
-if Travis isn't too annoyed someone will review it, and eventually merge
+if CI pipeline passes then someone will review it, and eventually merge
 it back.
-
-.. _flake8: https://flake8.pycqa.org/
-.. _sphinx: https://sphinx-doc.org/
-.. _tox: https://tox.readthedocs.io/

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,1 @@
+.. include:: ../CONTRIBUTING


### PR DESCRIPTION
This PR moves the contribution guidelines to a top-level CONTRIBUTING file.  It is still used as a ReStructuredText file so we need to be mindful with the format.  I stripped the superfluous links out so it the only real artifact is the `::` before a literal block.