### PR TITLE
Move readthedocs configuration into the repository.

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Flake8
         run: |
           flake8 sprockets tests.py
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -53,3 +54,19 @@ jobs:
           file: ./coverage.xml
           flags: unittests
           fail_ci_if_error: true
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Read the Docs compatible python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install '.[docs]'
+          python -m pip install .
+      - name: Build documentation
+        run: |
+          ./setup.py build_sphinx

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: 2
+python:
+  version: "3.7"
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+sphinx:
+  configuration: docs/conf.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,11 +68,3 @@ source = sprockets
 
 [flake8]
 exclude = build,env,.eggs
-
-[nosetests]
-cover-branches = 1
-cover-erase = 1
-cover-package = sprockets.mixins.mediatype
-logging-level=DEBUG
-verbosity=2
-with-coverage=1


### PR DESCRIPTION
The ReadTheDocs configuration is still referring to the requirements file which was removed. This should tell it to use the extra requirements section instead.

See https://docs.readthedocs.io/en/stable/config-file/v2.html for the configuration file format.