### PR TITLE
Add transcoder for `application/x-www-formurlencoded`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -54,6 +54,12 @@ Bundled Transcoders
 .. autoclass:: MsgPackTranscoder
    :members:
 
+.. autoclass:: FormUrlEncodedTranscoder
+   :members:
+
+.. autoclass:: FormUrlEncodingOptions
+   :members:
+
 .. _type-info:
 
 Python Type Information

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -9,6 +9,8 @@ Version History
   and there is no default content type configured
 - Deprecate not having a default content type configured
 - Fail gracefully when a transcoder does not exist for the default content type
+- Fail gracefully when a transcoder raises a :exc:`TypeError` or :exc:`ValueError` when encoding
+  the response
 
 .. _application/x-www-formurlencoded: https://url.spec.whatwg.org/#application/x-www-form-urlencoded
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,11 +3,14 @@ Version History
 
 :compare:`Next <3.0.4...master>`
 --------------------------------
+- Add a transcoder for `application/x-www-formurlencoded`_
 - Add type annotations (see :ref:`type-info`)
 - Return a "406 Not Acceptable" if the :http:header:`Accept` header values cannot be matched
   and there is no default content type configured
 - Deprecate not having a default content type configured
 - Fail gracefully when a transcoder does not exist for the default content type
+
+.. _application/x-www-formurlencoded: https://url.spec.whatwg.org/#application/x-www-form-urlencoded
 
 :compare:`3.0.4 <3.0.3...3.0.4>` (2 Nov 2020)
 ---------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,3 +87,6 @@ exclude = build,env,.eggs
 [mypy]
 mypy_path = typestubs
 strict = True
+
+[yapf]
+allow_split_before_dict_value = False

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -398,6 +398,10 @@ class FormUrlEncodedTranscoder:
         try:
             datum = self.options.literal_mapping[datum]  # type: ignore
         except (KeyError, TypeError):
+            if datum in {None, True, False}:
+                raise TypeError(
+                    f'{datum.__class__.__name__} is not serializable'
+                ) from None
             if isinstance(datum, (float, int, str)):
                 datum = str(datum)
             elif hasattr(datum, 'isoformat'):

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -405,7 +405,7 @@ class FormUrlEncodedTranscoder:
                     f'{datum.__class__.__name__} is not serializable'
                 ) from None
 
-            if isinstance(datum, (float, int, str)):
+            if isinstance(datum, (float, int, str, uuid.UUID)):
                 datum = str(datum)
             elif datum is not None and hasattr(datum, 'isoformat'):
                 datum = datum.isoformat()

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -276,6 +276,9 @@ class FormUrlEncodingOptions:
 class FormUrlEncodedTranscoder:
     """Opinionated transcoder for the venerable x-www-formurlencoded.
 
+    :param encoding_options: keyword parameters are used to initialize
+        :class:`FormUrlEncodingOptions`
+
     This transcoder implements transcoding according to the current
     W3C documentation.  The encoding interface takes mappings or
     sequences of pairs and encodes both the name and value.  The
@@ -329,8 +332,8 @@ class FormUrlEncodedTranscoder:
     """
     content_type = 'application/x-www-formurlencoded'
 
-    def __init__(self) -> None:
-        self.options = FormUrlEncodingOptions()
+    def __init__(self, **encoding_options) -> None:
+        self.options = FormUrlEncodingOptions(**encoding_options)
 
     def to_bytes(
             self,

--- a/sprockets/mixins/mediatype/type_info.py
+++ b/sprockets/mixins/mediatype/type_info.py
@@ -24,6 +24,10 @@ class HasSettings(Protocol):
     """Application settings."""
 
 
+SerializablePrimitives = (type(None), bool, bytearray, bytes, float, int,
+                          memoryview, str, uuid.UUID)
+"""Use this with isinstance to identify simple values."""
+
 Serializable = typing.Union[DefinesIsoFormat, None, bool, bytearray, bytes,
                             float, int, memoryview, str, typing.Mapping,
                             typing.Sequence, typing.Set, uuid.UUID]

--- a/sprockets/mixins/mediatype/type_info.py
+++ b/sprockets/mixins/mediatype/type_info.py
@@ -4,13 +4,14 @@ import typing
 import uuid
 
 try:
-    from typing import Protocol
+    from typing import Protocol, runtime_checkable
 except ImportError:
     # "ignore" is required to avoid an incompatible import
     # error due to different bindings of _SpecialForm
-    from typing_extensions import Protocol  # type: ignore
+    from typing_extensions import Protocol, runtime_checkable  # type: ignore
 
 
+@runtime_checkable
 class DefinesIsoFormat(Protocol):
     """An object that has an isoformat method."""
     def isoformat(self) -> str:

--- a/tests.py
+++ b/tests.py
@@ -636,3 +636,10 @@ class FormUrlEncodingTranscoderTests(unittest.TestCase):
         for value, expected in expectations.items():
             _, result = self.transcoder.to_bytes(value)
             self.assertEqual(expected, result)
+
+    def test_serialization_with_empty_literal_map(self):
+        self.transcoder: transcoders.FormUrlEncodedTranscoder
+        self.transcoder.options.literal_mapping.clear()
+        for value in {None, True, False}:
+            with self.assertRaises(TypeError):
+                self.transcoder.to_bytes(value)

--- a/tests.py
+++ b/tests.py
@@ -679,7 +679,22 @@ class FormUrlEncodingTranscoderTests(unittest.TestCase):
                 self.transcoder.to_bytes(value)
 
     def test_serialization_of_sequences(self):
-        sequence = [[1, 2, 3], {1, 2, 3}, (1, 2, 3)]
-        for value in sequence:
+        self.transcoder: transcoders.FormUrlEncodedTranscoder
+
+        always_illegal = [[1, 2, 3], {1, 2, 3}, (1, 2, 3)]
+
+        self.transcoder.options.encode_sequences = False
+        for value in always_illegal:
             with self.assertRaises(TypeError):
                 self.transcoder.to_bytes(value)
+
+        self.transcoder.options.encode_sequences = True
+        for value in always_illegal:
+            with self.assertRaises(TypeError):
+                self.transcoder.to_bytes(value)
+
+        self.transcoder.options.encode_sequences = True
+        value = {'list': [1, 2], 'tuple': (1, 2), 'set': {1, 2}, 'str': 'val'}
+        _, result = self.transcoder.to_bytes(value)
+        self.assertEqual(b'list=1&list=2&tuple=1&tuple=2&set=1&set=2&str=val',
+                         result)

--- a/tests.py
+++ b/tests.py
@@ -589,7 +589,7 @@ class FormUrlEncodingTranscoderTests(unittest.TestCase):
             ('', None),
             ('name', None),
         ])
-        self.assertEqual(b'=&=true&=false&=&name=', result)
+        self.assertEqual(b'=&=true&=false&&name', result)
 
     def test_serialization_using_plusses(self):
         self.transcoder: transcoders.FormUrlEncodedTranscoder
@@ -641,5 +641,11 @@ class FormUrlEncodingTranscoderTests(unittest.TestCase):
         self.transcoder: transcoders.FormUrlEncodedTranscoder
         self.transcoder.options.literal_mapping.clear()
         for value in {None, True, False}:
+            with self.assertRaises(TypeError):
+                self.transcoder.to_bytes(value)
+
+    def test_serialization_of_sequences(self):
+        sequence = [[1, 2, 3], {1, 2, 3}, (1, 2, 3)]
+        for value in sequence:
             with self.assertRaises(TypeError):
                 self.transcoder.to_bytes(value)

--- a/tests.py
+++ b/tests.py
@@ -561,11 +561,13 @@ class FormUrlEncodingTranscoderTests(unittest.TestCase):
 
     def test_simple_serialization(self):
         now = datetime.datetime.now()
+        id_val = uuid.uuid4()
         content_type, result = self.transcoder.to_bytes({
             'integer': 12,
             'float': math.pi,
             'string': 'percent quoted',
             'datetime': now,
+            'id': id_val,
         })
         self.assertEqual(content_type, 'application/x-www-formurlencoded')
         self.assertEqual(
@@ -574,6 +576,7 @@ class FormUrlEncodingTranscoderTests(unittest.TestCase):
                 f'float={math.pi}',
                 'string=percent%20quoted',
                 'datetime=' + now.isoformat().replace(':', '%3A'),
+                f'id={id_val}',
             ]))
 
     def test_that_serialization_encoding_can_be_overridden(self):
@@ -623,6 +626,7 @@ class FormUrlEncodingTranscoderTests(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_serialization_of_primitives(self):
+        id_val = uuid.uuid4()
         expectations = {
             None: b'',
             'a string': b'a%20string',
@@ -632,6 +636,7 @@ class FormUrlEncodingTranscoderTests(unittest.TestCase):
             False: b'false',
             b'\xfe\xed\xfa\xce': b'%FE%ED%FA%CE',
             memoryview(b'\xfe\xed\xfa\xce'): b'%FE%ED%FA%CE',
+            id_val: str(id_val).encode(),
         }
         for value, expected in expectations.items():
             _, result = self.transcoder.to_bytes(value)

--- a/tests.py
+++ b/tests.py
@@ -621,3 +621,18 @@ class FormUrlEncodingTranscoderTests(unittest.TestCase):
         expected = f'test_string={expected}'.encode()
         _, result = self.transcoder.to_bytes({'test_string': test_string})
         self.assertEqual(expected, result)
+
+    def test_serialization_of_primitives(self):
+        expectations = {
+            None: b'',
+            'a string': b'a%20string',
+            10: b'10',
+            2.3: str(2.3).encode(),
+            True: b'true',
+            False: b'false',
+            b'\xfe\xed\xfa\xce': b'%FE%ED%FA%CE',
+            memoryview(b'\xfe\xed\xfa\xce'): b'%FE%ED%FA%CE',
+        }
+        for value, expected in expectations.items():
+            _, result = self.transcoder.to_bytes(value)
+            self.assertEqual(expected, result)


### PR DESCRIPTION
This PR adds a new transcoder that handles the venerable URL encoding used by forms.  I discovered that `urllib.parse.urlencode` implements percent-encoding of the [RFC-3986](https://datatracker.ietf.org/doc/html/rfc3986) octets which differs from octet set specified by the [W3C URL Living Standard](https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set) in a single character.  This was changed in Python 3.7 ([bpo/16285](https://bugs.python.org/issue16285)).  Instead of relying on this, I wrote a simple inline transcoder whose performance is similar enough to `urllib.parse.urlencode`.

The implementation matches the behavior of `urllib.parse.urlencode` in other cases.  For example, nested collections are the percent-encoded stringified versions -- `{"list": [1, 2, 3]}` is encoded as `list=%5B1%2C%202%5D`.  The behavior can be controlled using the `encode_sequences` option which mimics the `doseq` parameter to `urlencode`.  The opinionated behavior is configurable by named parameters when creating the `FormUrlEncodedTranscoder`.  Make sure to build and look at the documentation to ensure that it makes sense to someone other than me ;)

Note that I plan on adding support for Python 3.10 in a closely following PR.