### PR TITLE
Support more types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Distribution
+on:
+  push:
+    branches-ignore: ["*"]
+    tags: ["*"]
+
+jobs:
+  upload-package:
+    name: "Build & upload package"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.repository == 'sprockets/sprockets.mixins.media_type' && startsWith(github.ref, 'refs/tags')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade build pip setuptools twine wheel
+      - name: Build distributions
+        run: |
+          python -m build --sdist --wheel --outdir dist/ .
+      - name: Upload packages
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_PASSWORD }}
+          skip_existing: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up python ${{ matrix.python-version }}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -99,3 +99,6 @@ Contract Types
 
 .. autoclass:: SupportsSettings
    :members:
+
+.. autoclass:: SupportsDataclassFields
+   :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -94,8 +94,8 @@ Convenience Types
 Contract Types
 ~~~~~~~~~~~~~~
 
-.. autoclass:: HasSettings
+.. autoclass:: SupportsIsoFormat
    :members:
 
-.. autoclass:: DefinesIsoFormat
+.. autoclass:: SupportsSettings
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,21 +36,18 @@ intersphinx_mapping = {
 # and the prefixed name (e.g., type_info.Deserialized) since both forms
 # appear in the typing annotations.
 extensions.append('sphinx.ext.autodoc')
+_names = {
+    'Deserialized', 'DumpSFunction', 'LoadSFunction', 'MsgPackable',
+    'PackBFunction', 'Serializable', 'SupportsIsoFormat', 'SupportsSettings',
+    'Transcoder', 'UnpackBFunction'
+}
 autodoc_type_aliases = {
     alias: f'sprockets.mixins.mediatype.type_info.{alias}'
-    for alias in {
-        'DefinesIsoFormat', 'Deserialized', 'DumpSFunction', 'HasSettings',
-        'LoadSFunction', 'MsgPackable', 'PackBFunction', 'Serializable',
-        'Transcoder', 'UnpackBFunction'
-    }
+    for alias in _names
 }
 autodoc_type_aliases.update({
     f'type_info.{alias}': f'sprockets.mixins.mediatype.type_info.{alias}'
-    for alias in {
-        'DefinesIsoFormat', 'Deserialized', 'DumpSFunction', 'HasSettings',
-        'LoadSFunction', 'MsgPackable', 'PackBFunction', 'Serializable',
-        'Transcoder', 'UnpackBFunction'
-    }
+    for alias in _names
 })
 
 # https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ Version History
 :compare:`Next <3.0.4...master>`
 --------------------------------
 - Add a transcoder for `application/x-www-formurlencoded`_
+- Add support for encoding :class:`decimal.Decimal`
 - Add type annotations (see :ref:`type-info`)
 - Return a "406 Not Acceptable" if the :http:header:`Accept` header values cannot be matched
   and there is no default content type configured

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,6 +6,7 @@ Version History
 - Add a transcoder for `application/x-www-formurlencoded`_
 - Add support for encoding :class:`decimal.Decimal`
 - Add support for encoding :func:`dataclasses.dataclass` decorated classes
+- Add support for encoding :class:`ipaddress.IPv4Address` and :class:`ipaddress.IPv6Address`
 - Add type annotations (see :ref:`type-info`)
 - Return a "406 Not Acceptable" if the :http:header:`Accept` header values cannot be matched
   and there is no default content type configured

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,6 +8,7 @@ Version History
 - Add support for encoding :func:`dataclasses.dataclass` decorated classes
 - Add support for encoding :class:`ipaddress.IPv4Address` and :class:`ipaddress.IPv6Address`
 - Add support for encoding :class:`pathlib.Path`
+- Add support for encoding :class:`array.array`
 - Add type annotations (see :ref:`type-info`)
 - Return a "406 Not Acceptable" if the :http:header:`Accept` header values cannot be matched
   and there is no default content type configured

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,7 @@ Version History
 - Add support for encoding :class:`decimal.Decimal`
 - Add support for encoding :func:`dataclasses.dataclass` decorated classes
 - Add support for encoding :class:`ipaddress.IPv4Address` and :class:`ipaddress.IPv6Address`
+- Add support for encoding :class:`pathlib.Path`
 - Add type annotations (see :ref:`type-info`)
 - Return a "406 Not Acceptable" if the :http:header:`Accept` header values cannot be matched
   and there is no default content type configured

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -9,6 +9,7 @@ Version History
 - Add support for encoding :class:`ipaddress.IPv4Address` and :class:`ipaddress.IPv6Address`
 - Add support for encoding :class:`pathlib.Path`
 - Add support for encoding :class:`array.array`
+- Add support for encoding :class:`collections.namedtuple` instances as tuples
 - Add type annotations (see :ref:`type-info`)
 - Return a "406 Not Acceptable" if the :http:header:`Accept` header values cannot be matched
   and there is no default content type configured

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -17,6 +17,7 @@ Version History
 - Fail gracefully when a transcoder does not exist for the default content type
 - Fail gracefully when a transcoder raises a :exc:`TypeError` or :exc:`ValueError` when encoding
   the response
+- Advertise support for Python 3.10
 
 .. _application/x-www-formurlencoded: https://url.spec.whatwg.org/#application/x-www-form-urlencoded
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,7 @@ Version History
 --------------------------------
 - Add a transcoder for `application/x-www-formurlencoded`_
 - Add support for encoding :class:`decimal.Decimal`
+- Add support for encoding :func:`dataclasses.dataclass` decorated classes
 - Add type annotations (see :ref:`type-info`)
 - Return a "406 Not Acceptable" if the :http:header:`Accept` header values cannot be matched
   and there is no default content type configured

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
+	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: Implementation :: CPython
 	Topic :: Software Development :: Libraries
 	Topic :: Software Development :: Libraries :: Python Modules

--- a/sprockets/mixins/mediatype/content.py
+++ b/sprockets/mixins/mediatype/content.py
@@ -154,7 +154,7 @@ class ContentSettings:
         self._default_content_type = new_value
 
 
-def install(application: type_info.HasSettings,
+def install(application: type_info.SupportsSettings,
             default_content_type: typing.Optional[str],
             encoding: typing.Optional[str] = None) -> ContentSettings:
     """Install the media type management settings and return it"""
@@ -170,20 +170,20 @@ def install(application: type_info.HasSettings,
 
 @typing.overload
 def get_settings(
-    application: type_info.HasSettings,
+    application: type_info.SupportsSettings,
     force_instance: Literal[False] = False
 ) -> typing.Union[ContentSettings, None]:
     ...  # pragma: no cover
 
 
 @typing.overload
-def get_settings(application: type_info.HasSettings,
+def get_settings(application: type_info.SupportsSettings,
                  force_instance: Literal[True]) -> ContentSettings:
     ...  # pragma: no cover
 
 
 def get_settings(
-        application: type_info.HasSettings,
+        application: type_info.SupportsSettings,
         force_instance: bool = False) -> typing.Union[ContentSettings, None]:
     """
     Retrieve the media type settings for a application.
@@ -205,7 +205,7 @@ def get_settings(
     return install(application, None)
 
 
-def add_binary_content_type(application: type_info.HasSettings,
+def add_binary_content_type(application: type_info.SupportsSettings,
                             content_type: str, pack: type_info.PackBFunction,
                             unpack: type_info.UnpackBFunction) -> None:
     """
@@ -223,7 +223,7 @@ def add_binary_content_type(application: type_info.HasSettings,
                    handlers.BinaryContentHandler(content_type, pack, unpack))
 
 
-def add_text_content_type(application: type_info.HasSettings,
+def add_text_content_type(application: type_info.SupportsSettings,
                           content_type: str, default_encoding: str,
                           dumps: type_info.DumpSFunction,
                           loads: type_info.LoadSFunction) -> None:
@@ -251,7 +251,7 @@ def add_text_content_type(application: type_info.HasSettings,
                                     default_encoding))
 
 
-def add_transcoder(application: type_info.HasSettings,
+def add_transcoder(application: type_info.SupportsSettings,
                    transcoder: type_info.Transcoder,
                    content_type: typing.Optional[str] = None) -> None:
     """
@@ -273,7 +273,7 @@ def add_transcoder(application: type_info.HasSettings,
     settings[content_type or transcoder.content_type] = transcoder
 
 
-def set_default_content_type(application: type_info.HasSettings,
+def set_default_content_type(application: type_info.SupportsSettings,
                              content_type: str,
                              encoding: typing.Optional[str] = None) -> None:
     """

--- a/sprockets/mixins/mediatype/content.py
+++ b/sprockets/mixins/mediatype/content.py
@@ -27,8 +27,6 @@ adds content handling methods to :class:`~tornado.web.RequestHandler`
 instances.
 
 """
-from __future__ import annotations
-
 import logging
 import typing
 import warnings

--- a/sprockets/mixins/mediatype/handlers.py
+++ b/sprockets/mixins/mediatype/handlers.py
@@ -7,8 +7,6 @@ Basic content handlers.
   to text before calling functions that encode & decode text
 
 """
-from __future__ import annotations
-
 import typing
 
 from tornado import escape

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -11,6 +11,7 @@ import dataclasses
 import decimal
 import ipaddress
 import json
+import pathlib
 import string
 import typing
 import urllib.parse
@@ -119,9 +120,11 @@ class JSONTranscoder(handlers.TextContentHandler):
         | :class:`ipaddress.IPv4Address` | Same as ``str(value.exploded)``    |
         | :class:`ipaddress.IPv6Address` |                                    |
         +--------------------------------+------------------------------------+
+        | :class:`pathlib.Path`          | Same as ``str(value)``             |
+        +--------------------------------+------------------------------------+
 
         """
-        if isinstance(obj, uuid.UUID):
+        if isinstance(obj, (pathlib.Path, uuid.UUID)):
             return str(obj)
         if hasattr(obj, 'isoformat'):
             return typing.cast(type_info.SupportsIsoFormat, obj).isoformat()
@@ -218,6 +221,8 @@ class MsgPackTranscoder(handlers.BinaryContentHandler):
         | Dataclasses                       | `map family`_ after calling   |
         |                                   | :func:`dataclasses.asdict`    |
         +-----------------------------------+-------------------------------+
+        | :class:`pathlib.Path`             | Same as ``str(value)``        |
+        +-----------------------------------+-------------------------------+
 
         .. _nil byte: https://github.com/msgpack/msgpack/blob/
            0b8f5ac67cdd130f4d4d4fe6afb839b989fdb86a/spec.md#formats-nil
@@ -249,7 +254,7 @@ class MsgPackTranscoder(handlers.BinaryContentHandler):
         if isinstance(datum, self.PACKABLE_TYPES):
             return datum
 
-        if isinstance(datum, uuid.UUID):
+        if isinstance(datum, (pathlib.Path, uuid.UUID)):
             datum = str(datum)
 
         if isinstance(datum, bytearray):
@@ -344,6 +349,8 @@ class FormUrlEncodedTranscoder:
     +--------------------------------+---------------------------------------+
     | :class:`ipaddress.IPv4Address` | ``str(v.exploded)``                   |
     | :class:`ipaddress.IPv6Address` |                                       |
+    +--------------------------------+---------------------------------------+
+    | :class:`pathlib.Path`          | Same as ``str(value)``                |
     +--------------------------------+---------------------------------------+
 
     https://url.spec.whatwg.org/#application/x-www-form-urlencoded

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -6,8 +6,6 @@ Bundled media type transcoders.
 - :class:`.FormUrlEncodedTranscoder` implements the venerable form encoding
 
 """
-from __future__ import annotations
-
 import base64
 import dataclasses
 import decimal
@@ -294,12 +292,13 @@ class FormUrlEncodingOptions:
     encode_sequences: bool = False
     """Encode sequence values as multiple name=value instances."""
 
-    literal_mapping: dict[typing.Literal[None, True, False],
-                          str] = dataclasses.field(default_factory=lambda: {
-                              None: '',
-                              True: 'true',
-                              False: 'false'
-                          })
+    literal_mapping: typing.Dict[typing.Union[None, bool],
+                                 str] = dataclasses.field(
+                                     default_factory=lambda: {
+                                         None: '',
+                                         True: 'true',
+                                         False: 'false'
+                                     })
     """Mapping from supported literal values to strings."""
 
     space_as_plus: bool = False

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -116,7 +116,7 @@ class JSONTranscoder(handlers.TextContentHandler):
         if isinstance(obj, uuid.UUID):
             return str(obj)
         if hasattr(obj, 'isoformat'):
-            return typing.cast(type_info.DefinesIsoFormat, obj).isoformat()
+            return typing.cast(type_info.SupportsIsoFormat, obj).isoformat()
         if isinstance(obj, (bytes, bytearray, memoryview)):
             return base64.b64encode(obj).decode('ASCII')
         raise TypeError('{!r} is not JSON serializable'.format(obj))
@@ -234,7 +234,7 @@ class MsgPackTranscoder(handlers.BinaryContentHandler):
             datum = datum.tobytes()
 
         if hasattr(datum, 'isoformat'):
-            datum = typing.cast(type_info.DefinesIsoFormat, datum).isoformat()
+            datum = typing.cast(type_info.SupportsIsoFormat, datum).isoformat()
 
         if isinstance(datum, (bytes, str)):
             return datum
@@ -429,7 +429,7 @@ class FormUrlEncodedTranscoder:
         return dict(output)
 
     def _encode(self, datum: typing.Union[bool, None, float, int, str,
-                                          type_info.DefinesIsoFormat],
+                                          type_info.SupportsIsoFormat],
                 char_map: typing.Mapping[int, str], encoding: str) -> str:
         if isinstance(datum, str):
             pass  # optimization: skip additional checks for strings
@@ -442,7 +442,7 @@ class FormUrlEncodedTranscoder:
             datum = self.options.literal_mapping[datum]  # type: ignore
         elif isinstance(datum, (bytearray, bytes, memoryview)):
             return ''.join(char_map[c] for c in datum)
-        elif isinstance(datum, type_info.DefinesIsoFormat):
+        elif isinstance(datum, type_info.SupportsIsoFormat):
             datum = datum.isoformat()
         else:
             datum = str(datum)

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -88,7 +88,7 @@ class JSONTranscoder(handlers.TextContentHandler):
                            json.loads(str_repr, **self.load_options))
 
     def dump_object(self,
-                    obj: type_info.Serializable) -> typing.Union[str, float]:
+                    obj: type_info.Serializable) -> type_info.JsonDumpable:
         """
         Called to encode unrecognized object.
 

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -506,6 +506,9 @@ class FormUrlEncodedTranscoder:
             return ''.join(char_map[c] for c in datum)
         elif isinstance(datum, type_info.SupportsIsoFormat):
             str_repr = datum.isoformat()
+        # the following check is for namedtuples
+        elif isinstance(datum, tuple) and datum.__class__ is not tuple:
+            str_repr = str(tuple(datum))
         else:
             str_repr = str(datum)
 

--- a/sprockets/mixins/mediatype/type_info.py
+++ b/sprockets/mixins/mediatype/type_info.py
@@ -12,24 +12,20 @@ except ImportError:
 
 
 @runtime_checkable
-class DefinesIsoFormat(Protocol):
+class SupportsIsoFormat(Protocol):
     """An object that has an isoformat method."""
     def isoformat(self) -> str:
         """Return the date/time in ISO-8601 format."""
         ...
 
 
-class HasSettings(Protocol):
+class SupportsSettings(Protocol):
     """Something that quacks like a tornado.web.Application."""
     settings: typing.Dict[str, typing.Any]
     """Application settings."""
 
 
-SerializablePrimitives = (type(None), bool, bytearray, bytes, float, int,
-                          memoryview, str, uuid.UUID)
-"""Use this with isinstance to identify simple values."""
-
-Serializable = typing.Union[DefinesIsoFormat, None, bool, bytearray, bytes,
+Serializable = typing.Union[SupportsIsoFormat, None, bool, bytearray, bytes,
                             float, int, memoryview, str, typing.Mapping,
                             typing.Sequence, typing.Set, uuid.UUID]
 """Types that can be serialized by this library.

--- a/sprockets/mixins/mediatype/type_info.py
+++ b/sprockets/mixins/mediatype/type_info.py
@@ -1,3 +1,4 @@
+import array
 import decimal
 import ipaddress
 import pathlib
@@ -42,7 +43,7 @@ Serializable = typing.Union[SupportsIsoFormat, None, bool, bytearray, bytes,
                             typing.Sequence, typing.Set, uuid.UUID,
                             decimal.Decimal, SupportsDataclassFields,
                             ipaddress.IPv4Address, ipaddress.IPv6Address,
-                            pathlib.Path]
+                            pathlib.Path, array.array]
 """Types that can be serialized by this library.
 
 This is the set of types that

--- a/sprockets/mixins/mediatype/type_info.py
+++ b/sprockets/mixins/mediatype/type_info.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import decimal
+import ipaddress
 import typing
 import uuid
 
@@ -40,7 +41,8 @@ class SupportsSettings(Protocol):
 Serializable = typing.Union[SupportsIsoFormat, None, bool, bytearray, bytes,
                             float, int, memoryview, str, typing.Mapping,
                             typing.Sequence, typing.Set, uuid.UUID,
-                            decimal.Decimal, SupportsDataclassFields]
+                            decimal.Decimal, SupportsDataclassFields,
+                            ipaddress.IPv4Address, ipaddress.IPv6Address]
 """Types that can be serialized by this library.
 
 This is the set of types that

--- a/sprockets/mixins/mediatype/type_info.py
+++ b/sprockets/mixins/mediatype/type_info.py
@@ -13,6 +13,17 @@ except ImportError:
 
 
 @runtime_checkable
+class SupportsDataclassFields(Protocol):
+    """An object that looks like a dataclass.
+
+    The implementation uses the same test that :func:`dataclasses.is_dataclass`
+    uses in Python 3.9.
+
+    """
+    __dataclass_fields__: typing.ClassVar[typing.Mapping[str, typing.Any]]
+
+
+@runtime_checkable
 class SupportsIsoFormat(Protocol):
     """An object that has an isoformat method."""
     def isoformat(self) -> str:
@@ -29,7 +40,7 @@ class SupportsSettings(Protocol):
 Serializable = typing.Union[SupportsIsoFormat, None, bool, bytearray, bytes,
                             float, int, memoryview, str, typing.Mapping,
                             typing.Sequence, typing.Set, uuid.UUID,
-                            decimal.Decimal]
+                            decimal.Decimal, SupportsDataclassFields]
 """Types that can be serialized by this library.
 
 This is the set of types that

--- a/sprockets/mixins/mediatype/type_info.py
+++ b/sprockets/mixins/mediatype/type_info.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import decimal
 import ipaddress
 import typing

--- a/sprockets/mixins/mediatype/type_info.py
+++ b/sprockets/mixins/mediatype/type_info.py
@@ -77,6 +77,10 @@ MsgPackable = typing.Union[None, bool, bytes, typing.Dict[typing.Any,
                            int, typing.List[typing.Any], str]
 """Set of types that the underlying msgpack library can serialize."""
 
+JsonDumpable = typing.Union[None, bool, typing.Mapping[typing.Any, typing.Any],
+                            float, int, typing.Sequence[typing.Any], str, None]
+"""Set of types that the underlying msgpack library can serialize."""
+
 
 class Transcoder(Protocol):
     """Object that transforms objects to bytes and back again.

--- a/sprockets/mixins/mediatype/type_info.py
+++ b/sprockets/mixins/mediatype/type_info.py
@@ -1,5 +1,6 @@
 import decimal
 import ipaddress
+import pathlib
 import typing
 import uuid
 
@@ -40,7 +41,8 @@ Serializable = typing.Union[SupportsIsoFormat, None, bool, bytearray, bytes,
                             float, int, memoryview, str, typing.Mapping,
                             typing.Sequence, typing.Set, uuid.UUID,
                             decimal.Decimal, SupportsDataclassFields,
-                            ipaddress.IPv4Address, ipaddress.IPv6Address]
+                            ipaddress.IPv4Address, ipaddress.IPv6Address,
+                            pathlib.Path]
 """Types that can be serialized by this library.
 
 This is the set of types that

--- a/sprockets/mixins/mediatype/type_info.py
+++ b/sprockets/mixins/mediatype/type_info.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import decimal
 import typing
 import uuid
 
@@ -27,7 +28,8 @@ class SupportsSettings(Protocol):
 
 Serializable = typing.Union[SupportsIsoFormat, None, bool, bytearray, bytes,
                             float, int, memoryview, str, typing.Mapping,
-                            typing.Sequence, typing.Set, uuid.UUID]
+                            typing.Sequence, typing.Set, uuid.UUID,
+                            decimal.Decimal]
 """Types that can be serialized by this library.
 
 This is the set of types that

--- a/tests.py
+++ b/tests.py
@@ -6,6 +6,7 @@ import ipaddress
 import json
 import math
 import os
+import pathlib
 import pickle
 import struct
 import typing
@@ -373,6 +374,11 @@ class JSONTranscoderTests(unittest.TestCase):
             dumped = self.transcoder.dumps({'addr': datum})
             self.assertEqual(dumped, '{"addr":"%s"}' % (datum.exploded, ))
 
+    def test_that_paths_are_supported(self):
+        p = pathlib.Path(__file__)
+        dumped = self.transcoder.dumps({'path': p})
+        self.assertEqual(dumped, '{"path":"%s"}' % (p, ))
+
 
 class ContentSettingsTests(unittest.TestCase):
     def test_that_handler_listed_in_available_content_types(self):
@@ -611,6 +617,11 @@ class MsgPackTranscoderTests(unittest.TestCase):
             dumped = self.transcoder.packb(datum)
             self.assertEqual(pack_string(datum.exploded), dumped)
 
+    def test_that_paths_are_supported(self):
+        p = pathlib.Path(__file__)
+        dumped = self.transcoder.packb(p)
+        self.assertEqual(pack_string(str(p)), dumped)
+
 
 class FormUrlEncodingTranscoderTests(unittest.TestCase):
     transcoder: type_info.Transcoder
@@ -777,3 +788,8 @@ class FormUrlEncodingTranscoderTests(unittest.TestCase):
             _, result = self.transcoder.to_bytes({'addr': datum})
             self.assertEqual(
                 f'addr={datum.exploded}'.replace(':', '%3A').encode(), result)
+
+    def test_that_paths_are_supported(self):
+        p = pathlib.Path(__file__)
+        _, result = self.transcoder.to_bytes({'path': p})
+        self.assertEqual(f'path={str(p)}'.replace('/', '%2F').encode(), result)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,coverage,docs,lint,typecheck
+envlist = py37,py38,py39,py310,coverage,docs,lint,typecheck
 indexserver =
     default = https://pypi.python.org/simple
 toxworkdir = build/tox


### PR DESCRIPTION
This PR adds transcoders for a pile of Standard Library types that we were lacking.  I decided to represent `decimal.Decimal` as `float` objects so that I didn't have to open the Pandora's Box of decimal contexts.  The interesting one was the representation of [array.array](https://docs.python.org/3/library/array.html#module-array) instances.  I ended up [using `tolist`](https://docs.python.org/3/library/array.html#array.array.tolist) which is interesting when you look at it.