### PR TITLE
Add pydantic support

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -99,3 +99,6 @@ Contract Types
 
 .. autoclass:: DefinesIsoFormat
    :members:
+
+.. autoclass:: PydanticModel
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ html_sidebars = {
 extensions.append('sphinx.ext.intersphinx')
 intersphinx_mapping = {
     'ietfparse': ('https://ietfparse.readthedocs.io/en/latest', None),
+    'pydantic': ('https://docs.pydantic.dev/latest', None),
     'python': ('https://docs.python.org/3', None),
     'requests': ('https://requests.readthedocs.org/en/latest/', None),
     'sprockets': ('https://sprockets.readthedocs.org/en/latest/', None),
@@ -37,6 +38,7 @@ autodoc_type_aliases = {
         'LoadSFunction',
         'MsgPackable',
         'PackBFunction',
+        'PydanticModel',
         'Serializable',
         'Transcoder',
         'UnpackBFunction',

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,6 +8,7 @@ Version History
 - Add type annotations (see :ref:`type-info`)
 - Return a "406 Not Acceptable" if the :http:header:`Accept` header values cannot be matched
   and there is no default content type configured
+- Add support for encoding :class:`pydantic.BaseModel` instances
 - Deprecate not having a default content type configured
 - Fail gracefully when a transcoder does not exist for the default content type
 - Fail gracefully when a transcoder raises a :exc:`TypeError` or :exc:`ValueError` when encoding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,17 @@ Source = "https://github.com/sprockets/sprockets.mixins.mediatype"
 
 [project.optional-dependencies]
 msgpack = ["u-msgpack-python>=2.5.0,<3"]
-ci = ["coverage[toml]>7.10", "mypy>=1.18,<1.19", "ruff>=0.12.11,<0.13"]
+ci = [
+  "coverage[toml]>7.10",
+  "mypy>=1.18,<1.19",
+  "pydantic>=2,<3",
+  "ruff>=0.12.11,<0.13",
+]
 dev = [
   "coverage>=7.10",
   "mypy>=1.18,<1.19",
   "pre-commit==4.3.0",
+  "pydantic>=2,<3",
   "ruff>=0.12.11,<0.13",
   "sphinx>=7.4,<9",
   "sphinx-rtd-theme>=3.0.2,<4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ Source = "https://github.com/sprockets/sprockets.mixins.mediatype"
 
 [project.optional-dependencies]
 msgpack = ["u-msgpack-python>=2.5.0,<3"]
-ci = ["coverage[toml]>7.10", "mypy==0.910", "ruff>=0.12.11,<0.13"]
+ci = ["coverage[toml]>7.10", "mypy>=1.18,<1.19", "ruff>=0.12.11,<0.13"]
 dev = [
   "coverage>=7.10",
-  "mypy==0.910",
+  "mypy>=1.18,<1.19",
   "pre-commit==4.3.0",
   "ruff>=0.12.11,<0.13",
   "sphinx>=7.4,<9",

--- a/sprockets/__init__.py
+++ b/sprockets/__init__.py
@@ -1,3 +1,3 @@
 import pkgutil
 
-__path__ = pkgutil.extend_path(__path__, __name__)  # type: ignore[has-type]
+__path__ = pkgutil.extend_path(__path__, __name__)

--- a/sprockets/mixins/__init__.py
+++ b/sprockets/mixins/__init__.py
@@ -1,3 +1,3 @@
 import pkgutil
 
-__path__ = pkgutil.extend_path(__path__, __name__)  # type: ignore[has-type]
+__path__ = pkgutil.extend_path(__path__, __name__)

--- a/sprockets/mixins/mediatype/content.py
+++ b/sprockets/mixins/mediatype/content.py
@@ -34,13 +34,6 @@ import logging
 import typing
 import warnings
 
-try:
-    from typing import Literal
-except ImportError:  # pragma: no cover
-    # "ignore" is required to avoid an incompatible import
-    # error due to different bindings of _SpecialForm
-    from typing_extensions import Literal  # type: ignore
-
 from ietfparse import algorithms, datastructures, errors, headers
 from tornado import web
 
@@ -190,13 +183,14 @@ def install(
 
 @typing.overload
 def get_settings(
-    application: type_info.HasSettings, force_instance: Literal[False] = False
+    application: type_info.HasSettings,
+    force_instance: typing.Literal[False] = False,
 ) -> typing.Union[ContentSettings, None]: ...  # pragma: no cover
 
 
 @typing.overload
 def get_settings(
-    application: type_info.HasSettings, force_instance: Literal[True]
+    application: type_info.HasSettings, force_instance: typing.Literal[True]
 ) -> ContentSettings: ...  # pragma: no cover
 
 

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -37,17 +37,27 @@ _FORM_URLENCODING.update({ord(c): c for c in '*-_.'})
 _FORM_URLENCODING_PLUS = _FORM_URLENCODING.copy()
 _FORM_URLENCODING_PLUS[ord(' ')] = '+'
 
-_COERCION_HOOKS: collections.abc.Mapping[
-    type[type_info.Serializable],
-    typing.Callable[[type_info.Serializable], str | bytes],
-] = {
-    uuid.UUID: lambda x: str(x),
-    bytearray: lambda x: bytes(typing.cast('bytearray', x)),
-    memoryview: lambda x: typing.cast('memoryview', x).tobytes(),
-    type_info.DefinesIsoFormat: lambda x: typing.cast(
-        'type_info.DefinesIsoFormat', x
-    ).isoformat(),
-}
+
+def _coerce_value(obj: type_info.Serializable) -> str | bytes | None:
+    """Common value coercion used for JSON & MsgPack.
+
+    Converts special types to their serializable representations:
+    - uuid.UUID -> str
+    - bytearray -> bytes
+    - memoryview -> bytes
+    - DefinesIsoFormat -> str (ISO format)
+
+    Returns None if the object type is not handled by this function.
+    """
+    if isinstance(obj, uuid.UUID):
+        return str(obj)
+    if isinstance(obj, bytearray):
+        return bytes(obj)
+    if isinstance(obj, memoryview):
+        return obj.tobytes()
+    if isinstance(obj, type_info.DefinesIsoFormat):
+        return obj.isoformat()
+    return None
 
 
 class JSONTranscoder(handlers.TextContentHandler):
@@ -138,12 +148,10 @@ class JSONTranscoder(handlers.TextContentHandler):
         +-----------------------------+---------------------------------------+
 
         """
-        for match_type, hook in _COERCION_HOOKS.items():
-            if isinstance(obj, match_type):
-                result = hook(obj)
-                if isinstance(result, bytes):
-                    result = base64.b64encode(result).decode('ASCII')
-                return result
+        if (result := _coerce_value(obj)) is not None:
+            if isinstance(result, bytes):
+                return base64.b64encode(result).decode('ASCII')
+            return result
         if pydantic is not None and isinstance(obj, pydantic.BaseModel):
             return obj.model_dump(mode='python')
         raise TypeError('{!r} is not JSON serializable'.format(obj))
@@ -257,9 +265,8 @@ class MsgPackTranscoder(handlers.BinaryContentHandler):
         if isinstance(datum, self.PACKABLE_TYPES):
             return datum
 
-        for match_type, hook in _COERCION_HOOKS.items():
-            if isinstance(datum, match_type):
-                datum = hook(datum)
+        if (result := _coerce_value(datum)) is not None:
+            datum = result
 
         if isinstance(datum, (bytes, str)):
             return datum

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -19,6 +19,10 @@ import urllib.parse
 import uuid
 
 try:
+    import pydantic
+except ImportError:  # pragma: no cover
+    pydantic = None  # type: ignore
+try:
     import umsgpack
 except ImportError:  # pragma: no cover
     umsgpack = None  # type: ignore
@@ -102,7 +106,9 @@ class JSONTranscoder(handlers.TextContentHandler):
             'type_info.Deserialized', json.loads(str_repr, **self.load_options)
         )
 
-    def dump_object(self, obj: type_info.Serializable) -> str:
+    def dump_object(
+        self, obj: type_info.Serializable
+    ) -> str | dict[str, object]:
         """
         Called to encode unrecognized object.
 
@@ -114,20 +120,22 @@ class JSONTranscoder(handlers.TextContentHandler):
         to :func:`json.dumps`.  It provides default representations for
         a number of Python language/standard library types.
 
-        +----------------------------+---------------------------------------+
-        | Python Type                | String Format                         |
-        +----------------------------+---------------------------------------+
-        | :class:`bytes`,            | Base64 encoded string.                |
-        | :class:`bytearray`,        |                                       |
-        | :class:`memoryview`        |                                       |
-        +----------------------------+---------------------------------------+
-        | :class:`datetime.datetime` | ISO8601 formatted timestamp in the    |
-        |                            | extended format including separators, |
-        |                            | milliseconds, and the timezone        |
-        |                            | designator.                           |
-        +----------------------------+---------------------------------------+
-        | :class:`uuid.UUID`         | Same as ``str(value)``                |
-        +----------------------------+---------------------------------------+
+        +-----------------------------+---------------------------------------+
+        | Python Type                 | String Format                         |
+        +-----------------------------+---------------------------------------+
+        | :class:`bytes`,             | Base64 encoded string.                |
+        | :class:`bytearray`,         |                                       |
+        | :class:`memoryview`         |                                       |
+        +-----------------------------+---------------------------------------+
+        | :class:`datetime.datetime`  | ISO8601 formatted timestamp in the    |
+        |                             | extended format including separators, |
+        |                             | milliseconds, and the timezone        |
+        |                             | designator.                           |
+        +-----------------------------+---------------------------------------+
+        | :class:`uuid.UUID`          | Same as ``str(value)``                |
+        +-----------------------------+---------------------------------------+
+        | :class:`pydantic.BaseModel` | `value.model_dump(mode='python')``    |
+        +-----------------------------+---------------------------------------+
 
         """
         for match_type, hook in _COERCION_HOOKS.items():
@@ -136,6 +144,8 @@ class JSONTranscoder(handlers.TextContentHandler):
                 if isinstance(result, bytes):
                     result = base64.b64encode(result).decode('ASCII')
                 return result
+        if pydantic is not None and isinstance(obj, pydantic.BaseModel):
+            return obj.model_dump(mode='python')
         raise TypeError('{!r} is not JSON serializable'.format(obj))
 
 
@@ -216,6 +226,12 @@ class MsgPackTranscoder(handlers.BinaryContentHandler):
         +-----------------------------------+-------------------------------+
         | :class:`uuid.UUID`                | Converted to String           |
         +-----------------------------------+-------------------------------+
+        | :class:`datetime.datetime`        | Converted to String           |
+        +-----------------------------------+-------------------------------+
+        | :class:`pydantic.BaseModel`       | Recursively encoded after     |
+        |                                   | calling ``model_dump()`` in   |
+        |                                   | "python" mode.                |
+        +-----------------------------------+-------------------------------+
 
         .. _nil byte: https://github.com/msgpack/msgpack/blob/
            0b8f5ac67cdd130f4d4d4fe6afb839b989fdb86a/spec.md#formats-nil
@@ -247,6 +263,9 @@ class MsgPackTranscoder(handlers.BinaryContentHandler):
 
         if isinstance(datum, (bytes, str)):
             return datum
+
+        if pydantic is not None and isinstance(datum, pydantic.BaseModel):
+            return self.normalize_datum(datum.model_dump(mode='python'))
 
         if isinstance(datum, (collections.abc.Sequence, collections.abc.Set)):
             return [self.normalize_datum(item) for item in datum]  # type: ignore[arg-type]
@@ -294,29 +313,32 @@ class FormUrlEncodedTranscoder:
     sequences of pairs and encodes both the name and value.  The
     following table describes how each supported type is encoded.
 
-    +----------------------------+---------------------------------------+
-    | Value / Type               | Encoding                              |
-    +============================+=======================================+
-    | character strings          | UTF-8 codepoints before percent-      |
-    |                            | encoding the resulting bytes          |
-    +----------------------------+---------------------------------------+
-    | space character            | ``%20`` or ``+``                      |
-    +----------------------------+---------------------------------------+
-    | :data:`False`              | ``false``                             |
-    +----------------------------+---------------------------------------+
-    | :data:`True`               | ``true``                              |
-    +----------------------------+---------------------------------------+
-    | :data:`None`               | the empty string                      |
-    +----------------------------+---------------------------------------+
-    | numbers                    | ``str(n)``                            |
-    +----------------------------+---------------------------------------+
-    | byte sequences             | percent-encoded bytes                 |
-    +----------------------------+---------------------------------------+
-    | :class:`uuid.UUID`         | ``str(u)``                            |
-    +----------------------------+---------------------------------------+
-    | :class:`datetime.datetime` | result of calling                     |
-    |                            | :meth:`~datetime.datetime.isoformat`  |
-    +----------------------------+---------------------------------------+
+    +-----------------------------+----------------------------------------+
+    | Value / Type                | Encoding                               |
+    +=============================+========================================+
+    | character strings           | UTF-8 codepoints before percent-       |
+    |                             | encoding the resulting bytes           |
+    +-----------------------------+----------------------------------------+
+    | space character             | ``%20`` or ``+``                       |
+    +-----------------------------+----------------------------------------+
+    | :data:`False`               | ``false``                              |
+    +-----------------------------+----------------------------------------+
+    | :data:`True`                | ``true``                               |
+    +-----------------------------+----------------------------------------+
+    | :data:`None`                | the empty string                       |
+    +-----------------------------+----------------------------------------+
+    | numbers                     | ``str(n)``                             |
+    +-----------------------------+----------------------------------------+
+    | byte sequences              | percent-encoded bytes                  |
+    +-----------------------------+----------------------------------------+
+    | :class:`uuid.UUID`          | ``str(u)``                             |
+    +-----------------------------+----------------------------------------+
+    | :class:`datetime.datetime`  | result of calling                      |
+    |                             | :meth:`~datetime.datetime.isoformat`   |
+    +-----------------------------+----------------------------------------+
+    | :class:`pydantic.BaseModel` | encoded after calling ``model_dump()`` |
+    |                             | in "python" mode                       |
+    +-----------------------------+----------------------------------------+
 
     https://url.spec.whatwg.org/#application/x-www-form-urlencoded
 
@@ -478,6 +500,8 @@ class FormUrlEncodedTranscoder:
         self, value: type_info.Serializable
     ) -> typing.Iterable[typing.Tuple[typing.Any, typing.Any]]:
         tuples: typing.Iterable[typing.Tuple[typing.Any, typing.Any]]
+        if pydantic is not None and isinstance(value, pydantic.BaseModel):
+            value = value.model_dump(mode='python')
         if isinstance(value, collections.abc.Mapping):
             tuples = value.items()
         else:

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -33,6 +33,18 @@ _FORM_URLENCODING.update({ord(c): c for c in '*-_.'})
 _FORM_URLENCODING_PLUS = _FORM_URLENCODING.copy()
 _FORM_URLENCODING_PLUS[ord(' ')] = '+'
 
+_COERCION_HOOKS: collections.abc.Mapping[
+    type[type_info.Serializable],
+    typing.Callable[[type_info.Serializable], str | bytes],
+] = {
+    uuid.UUID: lambda x: str(x),
+    bytearray: lambda x: bytes(typing.cast('bytearray', x)),
+    memoryview: lambda x: typing.cast('memoryview', x).tobytes(),
+    type_info.DefinesIsoFormat: lambda x: typing.cast(
+        'type_info.DefinesIsoFormat', x
+    ).isoformat(),
+}
+
 
 class JSONTranscoder(handlers.TextContentHandler):
     """
@@ -118,12 +130,12 @@ class JSONTranscoder(handlers.TextContentHandler):
         +----------------------------+---------------------------------------+
 
         """
-        if isinstance(obj, uuid.UUID):
-            return str(obj)
-        if hasattr(obj, 'isoformat'):
-            return typing.cast('type_info.DefinesIsoFormat', obj).isoformat()
-        if isinstance(obj, (bytes, bytearray, memoryview)):
-            return base64.b64encode(obj).decode('ASCII')
+        for match_type, hook in _COERCION_HOOKS.items():
+            if isinstance(obj, match_type):
+                result = hook(obj)
+                if isinstance(result, bytes):
+                    result = base64.b64encode(result).decode('ASCII')
+                return result
         raise TypeError('{!r} is not JSON serializable'.format(obj))
 
 
@@ -229,19 +241,9 @@ class MsgPackTranscoder(handlers.BinaryContentHandler):
         if isinstance(datum, self.PACKABLE_TYPES):
             return datum
 
-        if isinstance(datum, uuid.UUID):
-            datum = str(datum)
-
-        if isinstance(datum, bytearray):
-            datum = bytes(datum)
-
-        if isinstance(datum, memoryview):
-            datum = datum.tobytes()
-
-        if hasattr(datum, 'isoformat'):
-            datum = typing.cast(
-                'type_info.DefinesIsoFormat', datum
-            ).isoformat()
+        for match_type, hook in _COERCION_HOOKS.items():
+            if isinstance(datum, match_type):
+                datum = hook(datum)
 
         if isinstance(datum, (bytes, str)):
             return datum

--- a/sprockets/mixins/mediatype/transcoders.py
+++ b/sprockets/mixins/mediatype/transcoders.py
@@ -247,12 +247,12 @@ class MsgPackTranscoder(handlers.BinaryContentHandler):
             return datum
 
         if isinstance(datum, (collections.abc.Sequence, collections.abc.Set)):
-            return [self.normalize_datum(item) for item in datum]
+            return [self.normalize_datum(item) for item in datum]  # type: ignore[arg-type]
 
         if isinstance(datum, collections.abc.Mapping):
             out = {}
             for k, v in datum.items():
-                out[k] = self.normalize_datum(v)
+                out[k] = self.normalize_datum(v)  # type: ignore[arg-type]
             return out
 
         raise TypeError(

--- a/sprockets/mixins/mediatype/type_info.py
+++ b/sprockets/mixins/mediatype/type_info.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import typing
 import uuid
+from collections import abc
 
 try:
     from typing import Protocol, runtime_checkable
 except ImportError:
     # "ignore" is required to avoid an incompatible import
     # error due to different bindings of _SpecialForm
-    from typing_extensions import Protocol, runtime_checkable  # type: ignore
+    from typing_extensions import Protocol, runtime_checkable
 
 
 @runtime_checkable
@@ -40,7 +41,7 @@ SerializablePrimitives = (
 )
 """Use this with isinstance to identify simple values."""
 
-Serializable = typing.Union[
+Serializable: typing.TypeAlias = typing.Union[
     DefinesIsoFormat,
     None,
     bool,
@@ -50,9 +51,9 @@ Serializable = typing.Union[
     int,
     memoryview,
     str,
-    typing.Mapping,
-    typing.Sequence,
-    typing.Set,
+    abc.Mapping[str, object],
+    abc.Sequence[object],
+    abc.Set[object],
     uuid.UUID,
 ]
 """Types that can be serialized by this library.
@@ -63,7 +64,9 @@ is capable for serializing.
 
 """
 
-Deserialized = typing.Union[None, bytes, typing.Mapping, float, int, list, str]
+Deserialized = typing.Union[
+    None, bytes, abc.Mapping[str, object], float, int, list[object], str
+]
 """Possible result of deserializing a body.
 
 This is the set of types that
@@ -72,26 +75,26 @@ might return.
 
 """
 
-PackBFunction = typing.Callable[[Serializable], bytes]
+PackBFunction = abc.Callable[[Serializable], bytes]
 """Signature of a binary content handler's serialization hook."""
 
-UnpackBFunction = typing.Callable[[bytes], Deserialized]
+UnpackBFunction = abc.Callable[[bytes], Deserialized]
 """Signature of a binary content handler's deserialization hook."""
 
-DumpSFunction = typing.Callable[[Serializable], str]
+DumpSFunction = abc.Callable[[Serializable], str]
 """Signature of a text content handler's serialization hook."""
 
-LoadSFunction = typing.Callable[[str], Deserialized]
+LoadSFunction = abc.Callable[[str], Deserialized]
 """Signature of a text content handler's deserialization hook."""
 
 MsgPackable = typing.Union[
     None,
     bool,
     bytes,
-    typing.Dict[typing.Any, typing.Any],
+    dict[typing.Any, typing.Any],
     float,
     int,
-    typing.List[typing.Any],
+    list[typing.Any],
     str,
 ]
 """Set of types that the underlying msgpack library can serialize."""
@@ -114,8 +117,8 @@ class Transcoder(Protocol):
     """Canonical content type that this transcoder implements."""
 
     def to_bytes(
-        self, inst_data: Serializable, encoding: typing.Optional[str] = None
-    ) -> typing.Tuple[str, bytes]:
+        self, inst_data: Serializable, encoding: str | None = None
+    ) -> tuple[str, bytes]:
         """Serialize `inst_data` into a byte stream and content type spec.
 
         :param inst_data: the data to serialize
@@ -131,7 +134,7 @@ class Transcoder(Protocol):
         ...
 
     def from_bytes(
-        self, data_bytes: bytes, encoding: typing.Optional[str] = None
+        self, data_bytes: bytes, encoding: str | None = None
     ) -> Deserialized:
         """Deserialize `bytes` into a Python object instance.
 

--- a/sprockets/mixins/mediatype/type_info.py
+++ b/sprockets/mixins/mediatype/type_info.py
@@ -28,6 +28,23 @@ class HasSettings(Protocol):
     """Application settings."""
 
 
+T_Pydantic = typing.TypeVar('T_Pydantic', bound='PydanticModel')
+
+
+@runtime_checkable
+class PydanticModel(Protocol):
+    """Class that resembles a pydantic model."""
+
+    @classmethod
+    def model_validate(cls: type[T_Pydantic], obj: object) -> T_Pydantic:
+        """Validate an object and return a model instance."""
+        ...
+
+    def model_dump(self, *, mode: str) -> dict[str, typing.Any]:
+        """Serialize the model to a dictionary."""
+        ...
+
+
 SerializablePrimitives = (
     type(None),
     bool,
@@ -55,6 +72,7 @@ Serializable: typing.TypeAlias = typing.Union[
     abc.Sequence[object],
     abc.Set[object],
     uuid.UUID,
+    PydanticModel,
 ]
 """Types that can be serialized by this library.
 

--- a/tests.py
+++ b/tests.py
@@ -12,6 +12,7 @@ import unittest.mock
 import urllib.parse
 import uuid
 
+import pydantic
 import umsgpack
 from ietfparse import algorithms
 from tornado import httputil, testing, web
@@ -805,3 +806,61 @@ class FormUrlEncodingTranscoderTests(unittest.TestCase):
         self.assertEqual(
             b'list=1&list=2&tuple=1&tuple=2&set=1&set=2&str=val', result
         )
+
+
+class Item(pydantic.BaseModel):
+    name: str
+    price: float
+
+
+class WarehouseBin(pydantic.BaseModel):
+    location: str
+    last_verified: datetime.datetime
+    items: list[Item] = pydantic.Field(default_factory=list)
+
+
+class PydanticSupportTests(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        now = datetime.datetime.now(datetime.timezone.utc)
+        self.payload = WarehouseBin.model_validate(
+            {
+                'location': 'A1',
+                'last_verified': now,
+                'items': [
+                    {'name': 'Widget', 'price': 10.0},
+                    {'name': 'Gadget', 'price': 20.0},
+                ],
+            }
+        )
+        self.normalized = self.payload.model_dump(mode='python')
+        self.normalized['last_verified'] = now.isoformat()
+
+    def test_json_dumping(self) -> None:
+        transcoder = transcoders.JSONTranscoder()
+        _, result = transcoder.to_bytes(self.payload)
+        self.assertEqual(self.normalized, json.loads(result.decode()))
+        self.assertEqual(
+            self.payload,
+            WarehouseBin.model_validate(json.loads(result.decode())),
+        )
+
+    def test_msgpack_dumping(self) -> None:
+        transcoder = transcoders.MsgPackTranscoder()
+        _, result = transcoder.to_bytes(self.payload)
+        self.assertEqual(self.normalized, umsgpack.unpackb(result))
+        self.assertEqual(
+            self.payload,
+            WarehouseBin.model_validate(umsgpack.unpackb(result)),
+        )
+
+    def test_form_url_encoded_dumping(self) -> None:
+        transcoder = transcoders.FormUrlEncodedTranscoder(
+            encode_sequences=True
+        )
+        _, result = transcoder.to_bytes(self.payload)
+
+        expected = urllib.parse.urlencode(
+            self.normalized, doseq=True, quote_via=urllib.parse.quote
+        )
+        self.assertEqual(expected.encode(), result)

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import datetime
 import json
@@ -45,7 +47,7 @@ def pack_string(obj: object) -> bytes:
     return prefix + payload
 
 
-def pack_bytes(payload: bytes) -> bytes:
+def pack_bytes(payload: bytes | bytearray) -> bytes:
     """Optimally pack a byte string according to msgpack format"""
     pl = len(payload)
     if pl < (2**8):
@@ -346,7 +348,7 @@ class MixinCacheTests(unittest.TestCase):
             self.assertEqual(1, select_content_type.call_count)
 
     def test_that_request_body_is_cached(self) -> None:
-        self.transcoder.from_bytes = unittest.mock.Mock(  # type: ignore[assignment]
+        self.transcoder.from_bytes = unittest.mock.Mock(  # type: ignore[method-assign]
             wraps=self.transcoder.from_bytes
         )
         first = self.handler.get_request_body()

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+base_python = python3.12
 envlist = py39,py312,py313,docs,lint,typecheck
 indexserver =
     default = https://pypi.python.org/simple
@@ -11,7 +12,7 @@ extras =
     ci
     msgpack
 commands =
-    coverage run -m unittest tests.py
+    coverage run -m unittest -vb tests.py
     coverage report
 
 [testenv:docs]


### PR DESCRIPTION
  ## Summary

  This pull request adds Pydantic model support to sprockets.mixins.mediatype, allowing automatic serialization of Pydantic BaseModel instances across all supported content types (JSON, MessagePack, and form URL
  encoding).

## Key Changes

###  🚀 New Features

  - Pydantic BaseModel encoding support - All transcoders now automatically serialize Pydantic models using model_dump(mode='python')
  - Configuration-driven coercion hooks - Centralized type coercion system for extensibility
  - Enhanced type annotations - Improved typing throughout with modern Python standards

###  📝 Core Implementation

  - Added PydanticModel protocol in type_info.py:28-45 for type safety
  - Implemented centralized coercion hooks system in transcoders.py:40-50
  - Extended all three transcoders (JSON, MessagePack, FormUrlEncoded) to handle Pydantic models
  - Added comprehensive test suite with Item and WarehouseBin Pydantic models

###  🔧 Infrastructure Updates

  - Updated pyproject.toml to include Pydantic as optional dependency
  - Improved tox configuration with verbose test output
  - Enhanced documentation with Pydantic intersphinx mapping
  - Updated MyPy to version 1.18+ for better type checking

###  📚 Documentation

  - Added API documentation for PydanticModel protocol
  - Updated history with Pydantic support announcement
  - Enhanced transcoder documentation with Pydantic encoding details

  The changes maintain full backward compatibility while adding powerful new functionality for modern Python applications using Pydantic models.